### PR TITLE
Use the known SID for the `Users` group

### DIFF
--- a/oschmod/__init__.py
+++ b/oschmod/__init__.py
@@ -310,7 +310,7 @@ def win_get_other_sid():
     For now this is the Users builtin account. In the future, probably should
     allow account to be passed in and find any non-owner, non-group account
     currently associated with the file. As a default, it could use Users."""
-    return win32security.LookupAccountName(None, 'Users')[0]
+    return win32security.ConvertStringSidToSid("S-1-5-32-545")
 
 
 def convert_win_to_stat(win_perm, user_type, object_type):


### PR DESCRIPTION
The `Users` group is translated depending on the windows installation
language. Instead, use the known SID String published by Microsoft.
https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/security-identifiers-in-windows

Output from Pytest:

```
======================================================================================================================== test session starts ========================================================================================================================
platform win32 -- Python 3.8.6, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
rootdir: C:\Users\nurelin\oschmod, configfile: setup.cfg
collected 8 items                                                                                                                                                                                                                                                     

tests\test_oschmod.py ........                                                                                                                                                                                                                                 [100%] 

========================================================================================================================= warnings summary ========================================================================================================================== 
venv\lib\site-packages\_pytest\config\__init__.py:1230
  c:\users\nurelin\oschmod\venv\lib\site-packages\_pytest\config\__init__.py:1230: PytestConfigWarning: Unknown config option: mock_use_standalone_module

    self._warn_or_fail_if_strict("Unknown config option: {}\n".format(key))

venv\lib\site-packages\win32\lib\pywintypes.py:2
  c:\users\nurelin\oschmod\venv\lib\site-packages\win32\lib\pywintypes.py:2: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp, sys, os

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=================================================================================================================== 8 passed, 2 warnings in 4.35s ===================================================================================================================
```
