### PR TITLE
process windows paths for pathlib fixes #111

### DIFF
--- a/oschmod/__init__.py
+++ b/oschmod/__init__.py
@@ -361,7 +361,11 @@ def win_get_permissions(path):
     """Get the file or dir permissions."""
     if not os.path.exists(path):
         raise FileNotFoundError('Path %s could not be found.' % path)
-    str_path = _win_transform_pathlib_to_str(path)
+    
+    if isinstance(path, str):
+        str_path = path        
+    else:
+        str_path = _win_transform_pathlib_to_str(path)
 
     return _win_get_permissions(str_path, get_object_type(path))
 
@@ -401,7 +405,11 @@ def win_set_permissions(path, mode):
     """Set the file or dir permissions."""
     if not os.path.exists(path):
         raise FileNotFoundError('Path %s could not be found.' % path)
-    str_path = _win_transform_pathlib_to_str(path)
+
+    if isinstance(path, str):
+        str_path = path        
+    else:
+        str_path = _win_transform_pathlib_to_str(path)
 
     _win_set_permissions(str_path, mode, get_object_type(path))
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,3 @@
+mock==4.0.3
 pytest==6.1.2
 pywin32==301;platform_system=="Windows"

--- a/tests/test_oschmod_pathlib.py
+++ b/tests/test_oschmod_pathlib.py
@@ -7,18 +7,37 @@ import oschmod
 
 @mock.patch('oschmod._win_get_permissions')
 @mock.patch('oschmod._win_transform_pathlib_to_str')
-def test_win_get_permissions(transform_mock, get_permissions_mock):
+def test_win_get_permissions_string_path(transform_mock, get_permissions_mock):
     oschmod.win_get_permissions('.')
 
-    transform_mock.assert_called_once_with('.')
+    transform_mock.assert_not_called()
 
 
 @mock.patch('oschmod._win_set_permissions')
 @mock.patch('oschmod._win_transform_pathlib_to_str')
-def test_win_set_permissions(transform_mock, set_permissions_mock):
-    oschmod.win_set_permissions('.', "mock_mode")
+def test_win_set_permissions_string_path(transform_mock, set_permissions_mock):
+    oschmod.win_set_permissions('.', 'mock_mode')
 
-    transform_mock.assert_called_once_with('.')
+    transform_mock.assert_not_called()
+
+@mock.patch('oschmod._win_get_permissions')
+@mock.patch('oschmod._win_transform_pathlib_to_str')
+def test_win_get_permissions_path(transform_mock, get_permissions_mock):
+    mock_path = mock.MagicMock()
+
+    oschmod.win_get_permissions(mock_path)
+
+    transform_mock.assert_called_once_with(mock_path)
+
+
+@mock.patch('oschmod._win_set_permissions')
+@mock.patch('oschmod._win_transform_pathlib_to_str')
+def test_win_set_permissions_path(transform_mock, set_permissions_mock):
+    mock_path = mock.MagicMock()
+
+    oschmod.win_set_permissions(mock_path, 'mock_mode')
+
+    transform_mock.assert_called_once_with(mock_path)
 
 
 @mock.patch('oschmod.sys')

--- a/tests/test_oschmod_pathlib.py
+++ b/tests/test_oschmod_pathlib.py
@@ -1,0 +1,73 @@
+"""Unit tests for operations that might fail due to using Pathlib"""
+
+import mock
+import pytest
+
+import oschmod
+
+@mock.patch('oschmod._win_get_permissions')
+@mock.patch('oschmod._win_transform_pathlib_to_str')
+def test_win_get_permissions(transform_mock, get_permissions_mock):
+    oschmod.win_get_permissions('.')
+
+    transform_mock.assert_called_once_with('.')
+
+
+@mock.patch('oschmod._win_set_permissions')
+@mock.patch('oschmod._win_transform_pathlib_to_str')
+def test_win_set_permissions(transform_mock, set_permissions_mock):
+    oschmod.win_set_permissions('.', "mock_mode")
+
+    transform_mock.assert_called_once_with('.')
+
+
+@mock.patch('oschmod.sys')
+def test_win_transform_pathlib_to_str_negative_py26(mock_sys):
+    """Tests versions that do not support pathlib throws an exception.
+    py26 sys.version_info implemented different from >py26"""
+
+    mock_sys.version = '2.6.0'
+
+    with pytest.raises(RuntimeError, match='Pathlib not supported for <py34.'):
+        oschmod._win_transform_pathlib_to_str('mock_path')
+
+    mock_sys.version_info.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    'major_version, minor_version',
+    [(2, 7), (2, 9), (3, 2), (3, 3)],
+)
+@mock.patch('oschmod.sys')
+def test_win_transform_pathlib_to_str_negative(
+    mock_sys, major_version, minor_version
+):
+    """Tests versions that do not support pathlib throws an exception.
+    py27 is the only supported version by lib, but testing other edge
+    cases as well
+    """
+    mock_sys.version = '{}.{}'.format(major_version, minor_version)
+    mock_sys.version_info.major = major_version
+    mock_sys.version_info.minor = minor_version
+
+    with pytest.raises(RuntimeError, match='Pathlib not supported for <py34.'):
+        oschmod._win_transform_pathlib_to_str('mock_path')
+
+
+@pytest.mark.parametrize(
+    'major_version, minor_version',
+    [(3, 5), (3, 6), (3, 7), (3, 8)],
+)
+@mock.patch('oschmod.sys')
+def test_win_transform_pathlib_to_str_positive(
+    mock_sys, major_version, minor_version
+):
+    """Tests pathlib is transformed into a string for windows for
+    supported versions."""
+    mock_sys.version = '{}.{}'.format(major_version, minor_version)
+    mock_sys.version_info.major = major_version
+    mock_sys.version_info.minor = minor_version
+
+    actual_path = oschmod._win_transform_pathlib_to_str('mock_path')
+
+    assert actual_path == 'mock_path'


### PR DESCRIPTION
Fixes #111, mock is used for the py2 instances of tests (which don't seem to be part of the CI...?).

Changes proposed in this pull request:

* Convert all paths from windows operations to strings
* Detect unsupported python versions for pathlib paths and throw RuntimeError

Output from Pytest:

```
============================= test session starts =============================
platform win32 -- Python 3.9.6, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
rootdir: E:\Projects\oschmod, configfile: setup.cfg
collected 21 items

tests\test_oschmod.py ........                                           [ 38%]
tests\test_oschmod_pathlib.py .............                              [100%]

============================== warnings summary ===============================
..\oschmod_venv\lib\site-packages\_pytest\config\__init__.py:1230
  e:\projects\oschmod_venv\lib\site-packages\_pytest\config\__init__.py:1230: PytestConfigWarning: Unknown config option: mock_use_standalone_module

    self._warn_or_fail_if_strict("Unknown config option: {}\n".format(key))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================== 21 passed, 1 warning in 4.21s ========================

```
